### PR TITLE
limit calcs for chosen columns

### DIFF
--- a/cashflower/cashflow.py
+++ b/cashflower/cashflow.py
@@ -530,7 +530,18 @@ class Model:
     def set_queue(self):
         """Set an ordrer in which model components should be evaluated."""
         queue = []
-        components = sorted(self.components)
+
+        # User has chosen components, so there is no need to calculate all of them
+        if len(self.settings["OUTPUT_COLUMNS"]) > 0:
+            components = []
+            for component_name in self.settings["OUTPUT_COLUMNS"]:
+                component = self.get_component_by_name(component_name)
+                components = unique_append(components, component)
+                components = unique_extend(components, component.grandchildren)
+            components = sorted(components)
+        else:
+            components = sorted(self.components)
+
         while components:
             component = components[0]
 

--- a/tests/test_cashflow.py
+++ b/tests/test_cashflow.py
@@ -338,7 +338,8 @@ class TestModel(TestCase):
         b.grandchildren = [c]
         c.grandchildren = []
 
-        model = Model(None, [a, b, c], [], None, None)
+        settings = load_settings()
+        model = Model(None, [a, b, c], [], None, settings)
         model.set_queue()
         assert model.queue == [c, b, a]
 


### PR DESCRIPTION
If the user has chosen columns to be outputted (`OUTPUT_COLUMNS` setting), the model will calculate only variables which are need and not all of them.