### PR TITLE
Make output column order deterministic

### DIFF
--- a/cashflower/graph.py
+++ b/cashflower/graph.py
@@ -355,6 +355,7 @@ def set_cycle_order(dg_cycle):
     cycle_order = 0
     while dg_cycle.nodes:
         cycle_nodes_without_predecessors = [cn for cn in dg_cycle.nodes if len(list(dg_cycle.predecessors(cn))) == 0]
+        cycle_nodes_without_predecessors = sorted(cycle_nodes_without_predecessors, key=lambda node: node.name)
         if len(cycle_nodes_without_predecessors) > 0:
             for node in cycle_nodes_without_predecessors:
                 cycle_order += 1

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,35 @@
+import networkx as nx
+
+from cashflower.graph import set_cycle_order
+
+
+class Node:
+    """Minimal stand-in for a variable node (set_cycle_order only reads name and sets cycle_order)."""
+    def __init__(self, name):
+        self.name = name
+        self.cycle_order = None
+
+    def __repr__(self):
+        return self.name
+
+
+class TestSetCycleOrder:
+    def test_peers_at_same_level_are_ordered_by_name(self):
+        # 'x' and 'y' are peers: both depend on 'a' and are depended on by 'b'
+        # (mirrors dev_model_22, where x and y both `return a(t)`).
+        # Edges are inserted so that 'y' precedes 'x' in node order, which is the
+        # order that previously leaked into the output column order and made it
+        # non-deterministic across runs.
+        a, b, x, y = Node("a"), Node("b"), Node("x"), Node("y")
+        dg = nx.DiGraph()
+        dg.add_edge(a, y)
+        dg.add_edge(a, x)
+        dg.add_edge(y, b)
+        dg.add_edge(x, b)
+
+        set_cycle_order(dg)
+
+        assert a.cycle_order == 1
+        assert x.cycle_order == 2
+        assert y.cycle_order == 3
+        assert b.cycle_order == 4


### PR DESCRIPTION
Fixes #528.

## Problem

The order of columns in the model output is non-deterministic across runs. For `dev_model_22`, columns `x` and `y` swap places between runs (`t,a,x,y,...` vs `t,a,y,x,...`). The output should be deterministic so that end-users can reuse or compare results.

## Root cause

`x` and `y` are peer variables (both are `return a(t)`) and, together with `a` and `b`, form one strongly connected component, so they share the same `calc_order`. Within a cycle, relative order is decided by `cycle_order`, which is assigned in `set_cycle_order`. When several peer nodes are predecessor-free at the same level, that function assigned `cycle_order` in networkx's node-iteration order, which depends on `PYTHONHASHSEED` (it flows through `nx.simple_cycles` / strongly-connected-component set iteration). The swap reproduces on roughly 40% of hash seeds.

The final sort in `determine_calculation_order` already tiebreaks on `(calc_order, cycle_order, name)`, but because `cycle_order` itself differed between `x` and `y`, the `name` tiebreak never took effect.

## Fix

Sort the predecessor-free nodes by `name` before assigning `cycle_order`, so peers at the same cycle level get a stable order. This reuses the same name-based tiebreak convention already applied in the final sort.

## Testing

- Added `tests/test_graph.py`, which exercises `set_cycle_order` with peers inserted in reverse-name order; it fails without this change and passes with it.
- Verified on `dev_model_22` that the output column order is now `a,x,y,b,e,c,d` for every `PYTHONHASHSEED` tried (previously it swapped `x`/`y` on many seeds).
- Full suite passes (40 tests).

## Note

`process_acyclic_nodes` has the same node-iteration pattern but is currently stable in practice, because acyclic node order follows the alphabetical `inspect.getmembers` order. I left it untouched to keep the change minimal, but happy to add a matching sort there for defense-in-depth if you'd prefer.